### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ A survey of existing PDF-to-TXT solutions found no extant solutions that meet al
 13. Press **OK** on any remaining control panel windows.
 14. Download [OCR2Text](https://github.com/writecrow/ocr2text/archive/master.zip) to `Desktop\ocr`).
 15. Unzip the project.
-16. Open a `cmd.exe` terminal, and navigate to the folder via the command line (e.g., `cd Desktop\ocr\ocr2text-master`)
-17. Run `pip install --user --requirement requirements.txt`
-18. Optionally, you can check that you set up the PATH variable correctly in steps 6-10 by typing `echo %PATH%`. The output must include your equivalent of `C:\Users\mark\Desktop\ocr\Tesseract-OCR` and `C:\Users\mark\Desktop\ocr\poppler-0.68.0_x86\poppler-0.68.0\bin` for the script to work.
+16. If using Python version 3.8, open requirements.txt at your equivalent of `C:\Users\mark\Desktop\ocr\ocr2text-main\requirements.txt` and bump Pillow version from 6.2.0 to 6.2.1 or higher. 
+17. Open a `cmd.exe` terminal, and navigate to the folder via the command line (e.g., `cd Desktop\ocr\ocr2text-main`)
+18. Run `pip install --user --requirement requirements.txt`
+19. Optionally, you can check that you set up the PATH variable correctly in steps 6-10 by typing `echo %PATH%`. The output must include your equivalent of `C:\Users\mark\Desktop\ocr\Tesseract-OCR` and `C:\Users\mark\Desktop\ocr\poppler-0.68.0_x86\poppler-0.68.0\bin` for the script to work.
 
 
 ## macOS


### PR DESCRIPTION
# README Windows Directions Update

## Description

Closes issue #2 by updating directions.

Add a new step 16 between unzipping the project and running `pip install --user --requirement requirements.txt` which directs users who are running Python 3.8 to bump the Pillow version up. This circumvents an issue where installation was failing due to an older version of Pillow.

I would have also updated requirements.txt itself, but I don't know how that might affect macOS and Linux installations. Additionally, there is already an open pull request from Dependabot which messes with the Pillow dependency for the project in general.
